### PR TITLE
feat(game): add hanamikoji-1 two-player geisha card game (undeployed)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2240,6 +2240,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hanamikoji-1"
+version = "0.1.0"
+dependencies = [
+ "brdgme_cmd",
+ "brdgme_color",
+ "brdgme_game",
+ "brdgme_game_bin",
+ "brdgme_markup",
+ "rand 0.10.2",
+ "serde",
+]
+
+[[package]]
 name = "hashbag"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "game/farkle-2",
     "game/for-sale-2",
     "game/greed-2",
+    "game/hanamikoji-1",
     "game/jaipur-2",
     "game/liars-dice-2",
     "game/lords-of-vegas-1",

--- a/rust/game/hanamikoji-1/ADVANCED_STRATEGY.md
+++ b/rust/game/hanamikoji-1/ADVANCED_STRATEGY.md
@@ -1,0 +1,1 @@
+Hanamikoji advanced strategy placeholder - to be written.

--- a/rust/game/hanamikoji-1/ADVANCED_STRATEGY.md
+++ b/rust/game/hanamikoji-1/ADVANCED_STRATEGY.md
@@ -1,1 +1,34 @@
-Hanamikoji advanced strategy placeholder - to be written.
+# Hanamikoji - Advanced Strategy
+
+Higher-level strategic considerations.
+
+## I-cut-you-choose
+
+- In a gift you keep two cards and your opponent takes one; in a competition you keep one pair and they take the other. Your opponent always takes whichever option hurts you most, so you do not get to keep your favourite - you get the leftover.
+- Structure every offer so that both possible outcomes are acceptable to you. If one of the three gift cards would wreck you in the opponent's hands, do not offer it.
+- Use gifts and competitions to place cards on geisha you want while forcing the opponent to take cards that help them least. Two cards you keep on one geisha can win it outright.
+- A competition splits four cards into two pairs; pair them so the two pairs are close in value to you. Lopsided pairs let the opponent take the strong pair and leave you the weak one.
+
+## Action ordering
+
+- You draw one card per turn and spend 1, 2, 3 and 4 cards across your four actions, so your hand is largest early. Play competition (4 cards) and gift (3 cards) while you still have the cards; secret (1) and trade-off (2) can wait until your hand is small.
+- The starting player begins with seven cards and the other with six, then both draw each turn. If you are short on cards, you may be forced to take a small action first - plan the order so you are never unable to afford competition when you want it.
+- Save the trade-off for cards that genuinely help neither player, or for a pair you would otherwise be forced to gift away.
+
+## Markers across rounds
+
+- Victory markers persist between rounds, and a tied geisha keeps its current owner. If you already control a geisha, you can defend it cheaply - matching your opponent's cards keeps it yours without winning the count outright.
+- A geisha you do not control must be won by a strict majority, which costs one more card than your opponent has there. Contesting a defended geisha is expensive; pick your battles.
+- Early rounds set the board. Controlling high-charm geisha early forces your opponent to spend cards to claw them back in later rounds.
+
+## The two races
+
+- Track both the geisha count and the charm count at all times. The summary table shows both. A player at 3 geisha and 10 charm is one card from winning on either axis.
+- If you are racing on charm, prioritise Tea (5) and Taiko (4). If you are racing on geisha count, cheap low-charm geisha win just as well as expensive ones - four of any value ends the game.
+- Remember the tiebreak: if you reach four geisha but your opponent reaches eleven charm in the same scoring, they win. Do not tunnel-vision on geisha count while handing over the high-charm columns.
+
+## Reading the opponent
+
+- Each player has exactly one secret, revealed at scoring. The public `has_secret` flag and the cards you can see (your hand, face-up cards, the gift and competition discards) let you narrow down what their secret likely is.
+- Cards you cannot account for are in the opponent's hand, their secret, their trade-off or the one removed card. Counting these tells you which geisha they can still contest.
+- A player who has not used their secret late in the round is holding it for a geisha they care about - watch which geisha they have been building.

--- a/rust/game/hanamikoji-1/BASIC_STRATEGY.md
+++ b/rust/game/hanamikoji-1/BASIC_STRATEGY.md
@@ -1,0 +1,1 @@
+Hanamikoji basic strategy placeholder - to be written.

--- a/rust/game/hanamikoji-1/BASIC_STRATEGY.md
+++ b/rust/game/hanamikoji-1/BASIC_STRATEGY.md
@@ -1,1 +1,19 @@
-Hanamikoji basic strategy placeholder - to be written.
+# Hanamikoji - Basic Strategy
+
+Hard rules to avoid obviously bad moves.
+
+## Giving cards away
+
+- Never offer a card in a gift or competition that lets your opponent clinch a geisha they are one card from winning. They will take it, and you handed it to them.
+- Do not gift a high-charm geisha (Tea, Taiko) you are yourself trying to win. Your opponent can take the very card you need.
+- When you must give a card away, give one that helps you least and your opponent least - never a card that decides a geisha either way.
+
+## Discarding and hiding
+
+- Never trade off two cards of a geisha you could still win. Discarded cards score nothing; you cannot win a geisha you stripped yourself of.
+- Do not bury a card as your secret just to empty your hand. The secret is revealed and scores at round end - it is a scoring card, pick it to win a geisha.
+
+## Winning conditions
+
+- Do not ignore the 11-charm path. Four geisha is not the only way to win; three high-charm geisha (for example Tea, Taiko and Shamisen) already reach 11.
+- Never concede a geisha for free when a single card from you would tie it and keep the marker contested. A tied geisha changes no owner.

--- a/rust/game/hanamikoji-1/Cargo.toml
+++ b/rust/game/hanamikoji-1/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "hanamikoji-1"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+authors.workspace = true
+
+[dependencies]
+brdgme_game_bin = { path = "../../lib/game_bin" }
+brdgme_color = { path = "../../lib/color" }
+brdgme_game = { path = "../../lib/game" }
+brdgme_markup = { path = "../../lib/markup" }
+rand.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+brdgme_cmd = { path = "../../lib/cmd", features = ["test-support"] }
+
+[lints]
+workspace = true

--- a/rust/game/hanamikoji-1/DATA_DOCS.md
+++ b/rust/game/hanamikoji-1/DATA_DOCS.md
@@ -1,0 +1,1 @@
+Hanamikoji data docs placeholder - to be written.

--- a/rust/game/hanamikoji-1/DATA_DOCS.md
+++ b/rust/game/hanamikoji-1/DATA_DOCS.md
@@ -1,1 +1,51 @@
-Hanamikoji data docs placeholder - to be written.
+# Hanamikoji Data Dictionary
+
+## PubState (public information)
+
+- `players` (usize): Number of players in the game. Always 2.
+- `round` (u32): The current round number, starting at 1. Increments each time a round scores without a winner.
+- `finished` (bool): True once a winner has been decided.
+- `phase` (Phase): Which step of the turn the game is in. See the Phase enum below.
+- `current` (usize): The actor of the current real turn. During `OpponentChoose` this is still the player who played the gift or competition, not the player choosing.
+- `whose_turn` (Vec<usize>): The player(s) expected to act next. In `ChooseAction` this is `current`; in `OpponentChoose` it is the opponent (`1 - current`); empty when finished.
+- `starting` (usize): The player who takes the first turn this round. Alternates each round.
+- `deck_remaining` (usize): Number of cards left in the draw pile. The deck order is hidden and not present in the state.
+- `marker` (Vec<Option<usize>>): Victory marker position per geisha, indexed by geisha (Flute=0, Koto=1, Fan=2, Shamisen=3, Umbrella=4, Taiko=5, Tea=6). `None` means contested (no one controls it); `Some(p)` means player `p` controls it. Markers persist across rounds.
+- `faceup` (Vec<[u32; 2]>): Face-up card counts per geisha, indexed by geisha. Each entry is `[player0_count, player1_count]`. These are the cards placed on each side this round (gift, competition and revealed secrets); the majority decides the marker at scoring.
+- `used` (Vec<[bool; 4]>): Which of the four action markers each player has used this round, indexed by player. The four slots are `[secret, trade, gift, compete]`. `true` means spent.
+- `hand_counts` (Vec<usize>): Number of cards in each player's hand, indexed by player. Contents are hidden; only the count is public.
+- `has_secret` (Vec<bool>): Whether each player has a face-down secret card, indexed by player. The card's identity is hidden.
+- `traded_counts` (Vec<usize>): Number of cards each player has set aside for trade-off, indexed by player. Always 0 or 2. The card identities are hidden.
+- `pending` (Option<Pending>): The face-up pending choice, if a gift or competition is awaiting a response. See the Pending enum below. `None` when no choice is pending.
+- `geisha_counts` (Vec<usize>): Number of geisha each player currently controls, indexed by player. Reaching 4 wins.
+- `charms` (Vec<i32>): Charm points each player currently controls, indexed by player. The sum of the charm values of the geisha they control. Reaching 11 wins.
+- `winner` (Option<usize>): The winner, if the game is over. `None` while the game is in progress.
+
+## PlayerState (player-private information)
+
+- `public` (PubState): The full public game state, as described above.
+- `player` (usize): Which player this private state belongs to.
+- `hand` (Vec<Geisha>): This player's hand, as a multiset of geisha types. Cards of the same type are interchangeable. Sorted by geisha index.
+- `secret` (Option<Geisha>): This player's face-down secret card, if they have played one this round. `None` otherwise.
+- `traded` (Vec<Geisha>): This player's face-down trade-off discard for this round. Empty until they use the trade-off action, then two cards.
+
+The opponent's `hand`, `secret` and `traded` are never exposed - the public state carries only their counts (`hand_counts`, `has_secret`, `traded_counts`).
+
+## Phase enum
+
+- `ChooseAction`: The current player draws (automatically) and picks one of their unused actions.
+- `OpponentChoose`: A gift or competition is pending; the opponent of `current` must choose from the offered cards.
+- `Finished`: The game is over.
+
+## Pending enum
+
+The face-up cards awaiting a choice. Both variants are fully public.
+
+- `Gift { actor, cards }`: `actor` offered the three `cards`; the opponent takes one, `actor` keeps the other two.
+- `Competition { actor, sets }`: `actor` offered two pairs `sets[0]` and `sets[1]`; the opponent takes one pair, `actor` keeps the other.
+
+## Geisha enum
+
+The seven geisha, in board order, with their charm value. Each has three identical item cards.
+
+- `Flute` (2), `Koto` (2), `Fan` (2), `Shamisen` (3), `Umbrella` (3), `Taiko` (4), `Tea` (5). Charm totals 21.

--- a/rust/game/hanamikoji-1/PORTING_NOTES.md
+++ b/rust/game/hanamikoji-1/PORTING_NOTES.md
@@ -1,0 +1,1 @@
+Hanamikoji porting notes placeholder - to be written.

--- a/rust/game/hanamikoji-1/PORTING_NOTES.md
+++ b/rust/game/hanamikoji-1/PORTING_NOTES.md
@@ -1,1 +1,53 @@
-Hanamikoji porting notes placeholder - to be written.
+# Hanamikoji - Porting Notes
+
+Notes on the from-scratch rules interpretation for `hanamikoji-1`. This is a new
+implementation of Hanamikoji (EmperorS4), written from the rules rather than
+ported from existing code. Where the prose in `RULES.md` and the code could
+disagree, the code is authoritative.
+
+## Decisions
+
+- **D1 - automatic draw.** Drawing at the start of your turn is mandatory in the
+  rules, so it happens automatically on entering a player's turn
+  (`Game::begin_turn` in `src/lib.rs`). There is no `draw` command; a turn is
+  just one action.
+- **D2 - multiset hand.** The three item cards of a geisha are indistinguishable,
+  so a hand is a multiset of geisha types and commands reference cards by geisha
+  name (`secret tea`, `gift fan fan shamisen`), not by unique card ids.
+- **D3 - secret/trade-off redaction.** A player's secret and trade-off cards are
+  visible to their owner and hidden from the opponent. `PubState` carries only
+  counts and presence flags (`hand_counts`, `has_secret`, `traded_counts`); the
+  identities live only in `PlayerState`.
+- **D4 - public pending cards.** The cards offered by a gift or competition are
+  face-up, so `PubState.pending` exposes them in full (the three gift cards, or
+  the two competition pairs).
+- **D5 - automatic scoring and update.** Scoring and the round reset are
+  automatic transitions with no player-facing phase or command (`score_round`).
+  Only a win stops the game.
+- **D6 - ASCII geisha names.** The real game uses Japanese art names and colours.
+  The names here (Flute, Koto, Fan, Shamisen, Umbrella, Taiko, Tea) are a
+  cosmetic ASCII-friendly convention. Only the charm multiset {2,2,2,3,3,4,5}
+  and three-copies-per-type are mechanically meaningful; the name-to-value
+  mapping is decorative.
+- **D7 - charm beats geisha.** If one player reaches four geisha and the other
+  reaches eleven charm in the same scoring, the eleven-charm player wins
+  (`Game::decide_winner`). Only one player can hold eleven charm (charm sums to
+  21), so the tiebreak is unambiguous.
+
+## Command syntax
+
+- `secret <geisha>`, `trade <geisha> <geisha>`, `gift <geisha> <geisha> <geisha>`.
+- `compete <a> <b> <c> <d>` is two positional pairs: (a,b) is set 1 and (c,d) is
+  set 2. There is no separator token between the pairs.
+- The opponent resolves a gift with `choose <geisha>` (one of the offered cards)
+  and a competition with `choose 1` or `choose 2` (which set to take).
+- Geisha names parse case-insensitively.
+
+## Deployment status
+
+This crate mirrors `lords-of-vegas-1`: it is complete and tested but not
+deployed. Registration is a single line in the `rust/Cargo.toml` workspace
+members list (alphabetical, between `game/greed-2` and `game/jaipur-2`). There
+is no Dockerfile, docker-bake entry, Tiltfile target or k8s manifest, and no
+GameVersion CRD. The interface version is orthogonal to the `-1` crate suffix;
+if it were ever deployed it would declare `interfaceVersion: 2`.

--- a/rust/game/hanamikoji-1/RULES.md
+++ b/rust/game/hanamikoji-1/RULES.md
@@ -1,0 +1,1 @@
+Hanamikoji rules placeholder - to be written.

--- a/rust/game/hanamikoji-1/RULES.md
+++ b/rust/game/hanamikoji-1/RULES.md
@@ -1,1 +1,111 @@
-Hanamikoji rules placeholder - to be written.
+# Hanamikoji
+
+A two-player game of favour and majority. Seven geisha line the table; you and your rival court them by placing item cards on your side of each. Win a geisha by holding the majority of cards on it, then claim the game by controlling four geisha or eleven charm. Every card you commit is a card your opponent can see - except the ones you hide.
+
+## Components
+
+- Seven geisha, each with a charm value: Flute (2), Koto (2), Fan (2), Shamisen (3), Umbrella (3), Taiko (4), Tea (5). Charm totals 21.
+- 21 item cards: three identical cards per geisha, matching its type.
+- Four action markers per player: secret, trade-off, gift, competition. Each is used once per round.
+- A victory marker per geisha, tracking who currently controls it.
+
+## Setup
+
+- Shuffle the 21 item cards. Remove one unseen; it is out of the round and never revealed.
+- Deal six cards to each player. The remaining eight form the draw deck.
+- Choose a starting player at random.
+
+## The Round
+
+Players alternate turns, starting with the starting player, until each has taken four turns (eight turns total).
+
+On your turn you first draw one card from the deck (this is mandatory and happens automatically), then take exactly one of your four actions. The eight draws drain the deck exactly over the round. Each action may be used once per round, in any order; once used, its marker is spent for the round.
+
+Cards you place go on your side of the matching geisha. Cards are referred to by geisha type; the three cards of a type are interchangeable, so a hand is a multiset (for example `gift fan fan shamisen` offers two Fan cards and one Shamisen).
+
+## The Four Actions
+
+- **Secret** - place one card face-down (`secret tea`). It stays hidden until scoring, when it is revealed onto its geisha. Only you may look at it.
+- **Trade-off** - place two cards face-down, out of the round (`trade flute koto`). They are not scored this round. Only you may look at them.
+- **Gift** - offer three cards face-up (`gift flute koto fan`). Your opponent chooses one of the three for their side; you place the other two on yours.
+- **Competition** - offer four cards as two face-up pairs (`compete flute koto fan tea` makes pair 1 {Flute, Koto} and pair 2 {Fan, Tea}). Your opponent chooses one pair for their side; you place the other on yours.
+
+Gift and competition give your opponent a choice, so they pause for a response. While a choice is pending you must resolve it before anything else:
+
+- For a gift, take one of the offered cards by name (`choose fan`).
+- For a competition, take one of the two pairs (`choose 1` or `choose 2`).
+
+## Scoring
+
+When both players have spent all four actions, the round scores:
+
+1. Each player reveals their secret card onto its geisha.
+2. For each geisha, compare the number of cards on each side (face-up cards plus the just-revealed secret). The player with more cards wins the geisha and its victory marker moves to their side. A tie - or a geisha with no cards - leaves the marker where it was.
+3. Tally the geisha each player controls and the charm they carry (the sum of the charm values of those geisha).
+
+A player wins the game if, after scoring, they control four or more geisha, or carry eleven or more charm. If one player reaches four geisha and the other reaches eleven charm in the same scoring, the player with eleven charm wins.
+
+## Rounds and Game End
+
+If no one has won, a new round begins:
+
+- Victory markers stay where they are; control earned in earlier rounds persists.
+- All item cards - both sides, the trade-off discards and the removed card - are gathered, reshuffled into a fresh deck and re-dealt as in setup.
+- The other player becomes the starting player.
+
+Play continues round after round until a player meets a winning condition during scoring.
+
+## Reading the Display
+
+The display is brdgme markup. `{{player 0}}` and `{{player 1}}` mark the two players (the client shows their names), `{{b}}...{{/b}}` is bold and `{{fg <color>}}...{{/fg}}` colours a geisha name.
+
+The first line states the situation - whose turn it is, or who must resolve a pending choice - followed by the round number and how many cards remain in the deck.
+
+### The board
+
+The first table has one row per geisha, always in the order Flute, Koto, Fan, Shamisen, Umbrella, Taiko, Tea. Columns are: the geisha, its charm value, `{{player 0}}`'s face-up card count, the victory marker, and `{{player 1}}`'s face-up count. The marker column reads `< {{player 0}}` when player 0 controls the geisha, `{{player 1}} >` when player 1 controls it, and a grey `-` while it is unclaimed.
+
+Here is a real mid-game board, in round 2 with two geisha claimed by each player and several cards already placed:
+
+```brdgme
+{{b}}{{player 1}}'s turn - choose an action (secret, trade, gift or compete){{/b}}Round 2  -  1 cards left in the deck
+{{table}}{{row}}{{cell left}}{{b}}Geisha{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}Charm{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{player 0}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}Marker{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{player 1}}{{/cell}}{{/row}}{{row}}{{cell left}}{{b}}{{fg cyan}}Flute{{/fg}}{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}2{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}0{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{fg grey}}-{{/fg}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}0{{/b}}{{/cell}}{{/row}}{{row}}{{cell left}}{{b}}{{fg green}}Koto{{/fg}}{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}2{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}0{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{player 1}}{{b}} >{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}0{{/b}}{{/cell}}{{/row}}{{row}}{{cell left}}{{b}}{{fg pink}}Fan{{/fg}}{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}2{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}1{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{fg grey}}-{{/fg}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}1{{/b}}{{/cell}}{{/row}}{{row}}{{cell left}}{{b}}{{fg purple}}Shamisen{{/fg}}{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}3{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}1{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}< {{/b}}{{player 0}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}0{{/b}}{{/cell}}{{/row}}{{row}}{{cell left}}{{b}}{{fg blue}}Umbrella{{/fg}}{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}3{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}1{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}< {{/b}}{{player 0}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}1{{/b}}{{/cell}}{{/row}}{{row}}{{cell left}}{{b}}{{fg orange}}Taiko{{/fg}}{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}4{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}0{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{player 1}}{{b}} >{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}1{{/b}}{{/cell}}{{/row}}{{row}}{{cell left}}{{b}}{{fg yellow}}Tea{{/fg}}{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}5{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}0{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{fg grey}}-{{/fg}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}0{{/b}}{{/cell}}{{/row}}{{/table}}
+{{table}}{{row}}{{cell left}}{{b}}Player{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}Geisha{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}Charm{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}Hand{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}Secret{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}Traded{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell left}}{{b}}Actions{{/b}}{{/cell}}{{/row}}{{row}}{{cell left}}{{player 0}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}2{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}6{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}3{{/cell}}{{cell left}}  {{/cell}}{{cell center}}yes{{/cell}}{{cell left}}  {{/cell}}{{cell center}}2{{/cell}}{{cell left}}  {{/cell}}{{cell left}}{{fg grey}}S{{/fg}} {{fg grey}}T{{/fg}} {{fg grey}}G{{/fg}} {{b}}{{fg green}}C{{/fg}}{{/b}}{{/cell}}{{/row}}{{row}}{{cell left}}{{player 1}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}2{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}{{b}}6{{/b}}{{/cell}}{{cell left}}  {{/cell}}{{cell center}}4{{/cell}}{{cell left}}  {{/cell}}{{cell center}}yes{{/cell}}{{cell left}}  {{/cell}}{{cell center}}2{{/cell}}{{cell left}}  {{/cell}}{{cell left}}{{fg grey}}S{{/fg}} {{fg grey}}T{{/fg}} {{fg grey}}G{{/fg}} {{b}}{{fg green}}C{{/fg}}{{/b}}{{/cell}}{{/row}}{{/table}}
+```
+
+### The pending choice
+
+When a gift or competition is waiting for a response, a line above the board describes the offer. A gift lists its three cards; a competition lists its two pairs (a literal opening brace appears as `{{lbrace}}`):
+
+```brdgme
+{{b}}Competition: {{/b}}{{player 1}} offered set 1 {{lbrace}} {{b}}{{fg purple}}Shamisen{{/fg}}{{/b}}, {{b}}{{fg orange}}Taiko{{/fg}}{{/b}} } and set 2 {{lbrace}} {{b}}{{fg yellow}}Tea{{/fg}}{{/b}}, {{b}}{{fg yellow}}Tea{{/fg}}{{/b}} } - {{player 0}}{{b}} chooses a set{{/b}}
+```
+
+### The summary
+
+The second table summarises each player: geisha controlled, charm carried, hand size, whether they have a face-down secret (`yes` or a grey `-`), how many cards they have set aside for trade-off, and their four action markers - `S T G C`, bold green while available and grey once spent.
+
+### Hidden information
+
+The deck order, hand contents, secret identity and trade-off identities are never shown - only counts and public consequences appear. Your own private cards are appended below the board in your player view:
+
+```brdgme
+{{b}}Your hand: {{/b}}{{b}}{{fg purple}}Shamisen{{/fg}}{{/b}}, {{b}}{{fg orange}}Taiko{{/fg}}{{/b}}, {{b}}{{fg yellow}}Tea{{/fg}}{{/b}}, {{b}}{{fg yellow}}Tea{{/fg}}{{/b}}
+{{b}}Your secret: {{/b}}{{b}}{{fg cyan}}Flute{{/fg}}{{/b}}
+{{b}}Your trade-off discard: {{/b}}{{b}}{{fg pink}}Fan{{/fg}}{{/b}}, {{b}}{{fg purple}}Shamisen{{/fg}}{{/b}}
+```
+
+The opponent's hand, secret and trade-off stay hidden; you see only their counts in the summary table.
+
+## Commands
+
+| Command | Action | Example |
+|---------|--------|---------|
+| `secret <geisha>` | Place one card face-down (revealed at scoring) | `secret tea` |
+| `trade <geisha> <geisha>` | Set two cards aside face-down, out of the round | `trade flute koto` |
+| `gift <geisha> <geisha> <geisha>` | Offer three cards; opponent takes one | `gift flute koto fan` |
+| `compete <a> <b> <c> <d>` | Offer four cards as two pairs (a,b) and (c,d); opponent takes one pair | `compete flute koto fan tea` |
+| `choose <geisha>` | Take one card from a pending gift | `choose fan` |
+| `choose <set>` | Take one pair from a pending competition (set is 1 or 2) | `choose 2` |
+
+Geisha names are case-insensitive. Only the commands you can legally make right now are offered; drawing is automatic and has no command.

--- a/rust/game/hanamikoji-1/src/bin/hanamikoji_1_cli.rs
+++ b/rust/game/hanamikoji-1/src/bin/hanamikoji_1_cli.rs
@@ -1,0 +1,3 @@
+fn main() {
+    brdgme_game_bin::cli_main::<hanamikoji_1::Game>();
+}

--- a/rust/game/hanamikoji-1/src/bin/hanamikoji_1_fuzz.rs
+++ b/rust/game/hanamikoji-1/src/bin/hanamikoji_1_fuzz.rs
@@ -1,0 +1,3 @@
+fn main() {
+    brdgme_game_bin::fuzz_main::<hanamikoji_1::Game>();
+}

--- a/rust/game/hanamikoji-1/src/bin/hanamikoji_1_http.rs
+++ b/rust/game/hanamikoji-1/src/bin/hanamikoji_1_http.rs
@@ -1,0 +1,3 @@
+fn main() {
+    brdgme_game_bin::http_main::<hanamikoji_1::Game>();
+}

--- a/rust/game/hanamikoji-1/src/card.rs
+++ b/rust/game/hanamikoji-1/src/card.rs
@@ -1,0 +1,96 @@
+use std::fmt;
+
+use brdgme_color::NamedColor;
+use serde::{Deserialize, Serialize};
+
+/// The seven geisha, ordered by ascending charm so that `index` is a stable
+/// 0..7 board position. Charm values are the standard distribution
+/// {2,2,2,3,3,4,5} (sum 21); the name-to-value mapping is cosmetic (the real
+/// game uses Japanese art names), only the multiset and 3-copies-each matter.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Geisha {
+    Flute,
+    Koto,
+    Fan,
+    Shamisen,
+    Umbrella,
+    Taiko,
+    Tea,
+}
+
+impl Geisha {
+    pub const ALL: [Geisha; 7] = [
+        Geisha::Flute,
+        Geisha::Koto,
+        Geisha::Fan,
+        Geisha::Shamisen,
+        Geisha::Umbrella,
+        Geisha::Taiko,
+        Geisha::Tea,
+    ];
+
+    pub fn charm(self) -> i32 {
+        match self {
+            Geisha::Flute => 2,
+            Geisha::Koto => 2,
+            Geisha::Fan => 2,
+            Geisha::Shamisen => 3,
+            Geisha::Umbrella => 3,
+            Geisha::Taiko => 4,
+            Geisha::Tea => 5,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Geisha::Flute => "Flute",
+            Geisha::Koto => "Koto",
+            Geisha::Fan => "Fan",
+            Geisha::Shamisen => "Shamisen",
+            Geisha::Umbrella => "Umbrella",
+            Geisha::Taiko => "Taiko",
+            Geisha::Tea => "Tea",
+        }
+    }
+
+    pub fn color(self) -> NamedColor {
+        match self {
+            Geisha::Flute => NamedColor::Cyan,
+            Geisha::Koto => NamedColor::Green,
+            Geisha::Fan => NamedColor::Pink,
+            Geisha::Shamisen => NamedColor::Purple,
+            Geisha::Umbrella => NamedColor::Blue,
+            Geisha::Taiko => NamedColor::Orange,
+            Geisha::Tea => NamedColor::Yellow,
+        }
+    }
+
+    pub fn index(self) -> usize {
+        match self {
+            Geisha::Flute => 0,
+            Geisha::Koto => 1,
+            Geisha::Fan => 2,
+            Geisha::Shamisen => 3,
+            Geisha::Umbrella => 4,
+            Geisha::Taiko => 5,
+            Geisha::Tea => 6,
+        }
+    }
+
+    /// The full 21-card deck: three identical item cards per geisha.
+    pub fn full_deck() -> Vec<Geisha> {
+        let mut deck: Vec<Geisha> = vec![];
+        for g in Geisha::ALL {
+            for _ in 0..3 {
+                deck.push(g);
+            }
+        }
+        deck
+    }
+}
+
+impl fmt::Display for Geisha {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}

--- a/rust/game/hanamikoji-1/src/command.rs
+++ b/rust/game/hanamikoji-1/src/command.rs
@@ -1,0 +1,206 @@
+use brdgme_game::Gamer;
+use brdgme_game::command::parser::*;
+
+use crate::card::Geisha;
+use crate::{Game, Pending, Phase};
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum Command {
+    Secret(Geisha),
+    Trade(Geisha, Geisha),
+    Gift(Geisha, Geisha, Geisha),
+    Compete(Geisha, Geisha, Geisha, Geisha),
+    ChooseCard(Geisha),
+    ChooseSet(usize),
+}
+
+pub fn geisha_parser() -> impl Parser<T = Geisha> {
+    Enum::exact(Geisha::ALL.to_vec())
+}
+
+impl Game {
+    pub fn command_parser(&self, player: usize) -> Option<Box<dyn Parser<T = Command> + '_>> {
+        if self.is_finished() {
+            return None;
+        }
+        let mut parsers: Vec<Box<dyn Parser<T = Command>>> = vec![];
+        match self.phase {
+            Phase::ChooseAction if player == self.current => {
+                let hand = self.hands.get(player).map(Vec::len).unwrap_or(0);
+                let used = self.used.get(player).copied().unwrap_or([true; 4]);
+                if !used[0] && hand >= 1 {
+                    parsers.push(Box::new(secret_parser()));
+                }
+                if !used[1] && hand >= 2 {
+                    parsers.push(Box::new(trade_parser()));
+                }
+                if !used[2] && hand >= 3 {
+                    parsers.push(Box::new(gift_parser()));
+                }
+                if !used[3] && hand >= 4 {
+                    parsers.push(Box::new(compete_parser()));
+                }
+            }
+            Phase::OpponentChoose if player == 1 - self.current => match &self.pending {
+                Some(Pending::Gift { cards, .. }) => {
+                    parsers.push(Box::new(choose_card_parser(cards)));
+                }
+                Some(Pending::Competition { .. }) => {
+                    parsers.push(Box::new(choose_set_parser()));
+                }
+                None => {}
+            },
+            _ => {}
+        }
+        if parsers.is_empty() {
+            None
+        } else {
+            Some(Box::new(OneOf::new(parsers)))
+        }
+    }
+}
+
+pub fn secret_parser() -> impl Parser<T = Command> {
+    Map::new(
+        Chain2::new(
+            Doc::name_desc(
+                "secret",
+                "play one card face-down; it is revealed and scored at the end of the round",
+                Token::new("secret"),
+            ),
+            AfterSpace::new(Doc::name_desc(
+                "geisha",
+                "the card to play face-down",
+                geisha_parser(),
+            )),
+        ),
+        |(_, g)| Command::Secret(g),
+    )
+}
+
+pub fn trade_parser() -> impl Parser<T = Command> {
+    Map::new(
+        Chain3::new(
+            Doc::name_desc(
+                "trade",
+                "set two cards aside face-down, out of the round (not scored)",
+                Token::new("trade"),
+            ),
+            AfterSpace::new(Doc::name_desc(
+                "geisha",
+                "the first card to set aside",
+                geisha_parser(),
+            )),
+            AfterSpace::new(Doc::name_desc(
+                "geisha",
+                "the second card to set aside",
+                geisha_parser(),
+            )),
+        ),
+        |(_, a, b)| Command::Trade(a, b),
+    )
+}
+
+pub fn gift_parser() -> impl Parser<T = Command> {
+    Map::new(
+        Chain4::new(
+            Doc::name_desc(
+                "gift",
+                "offer three cards face-up; your opponent takes one, you place the other two",
+                Token::new("gift"),
+            ),
+            AfterSpace::new(Doc::name_desc(
+                "geisha",
+                "the first gift card",
+                geisha_parser(),
+            )),
+            AfterSpace::new(Doc::name_desc(
+                "geisha",
+                "the second gift card",
+                geisha_parser(),
+            )),
+            AfterSpace::new(Doc::name_desc(
+                "geisha",
+                "the third gift card",
+                geisha_parser(),
+            )),
+        ),
+        |(_, a, b, c)| Command::Gift(a, b, c),
+    )
+}
+
+pub fn compete_parser() -> impl Parser<T = Command> {
+    Map::new(
+        Chain2::new(
+            Chain3::new(
+                Doc::name_desc(
+                    "compete",
+                    "play four cards as two face-up pairs; your opponent takes one pair, you place the other",
+                    Token::new("compete"),
+                ),
+                AfterSpace::new(Doc::name_desc(
+                    "geisha",
+                    "first card of your first pair",
+                    geisha_parser(),
+                )),
+                AfterSpace::new(Doc::name_desc(
+                    "geisha",
+                    "second card of your first pair",
+                    geisha_parser(),
+                )),
+            ),
+            Chain2::new(
+                AfterSpace::new(Doc::name_desc(
+                    "geisha",
+                    "first card of your second pair",
+                    geisha_parser(),
+                )),
+                AfterSpace::new(Doc::name_desc(
+                    "geisha",
+                    "second card of your second pair",
+                    geisha_parser(),
+                )),
+            ),
+        ),
+        |((_, a, b), (c, d))| Command::Compete(a, b, c, d),
+    )
+}
+
+pub fn choose_card_parser(cards: &[Geisha]) -> impl Parser<T = Command> {
+    let mut distinct = cards.to_vec();
+    distinct.sort_by_key(|g| g.index());
+    distinct.dedup();
+    Map::new(
+        Chain2::new(
+            Doc::name_desc(
+                "choose",
+                "choose one of the gift cards to place on your side",
+                Token::new("choose"),
+            ),
+            AfterSpace::new(Doc::name_desc(
+                "geisha",
+                "the gift card to take",
+                Enum::exact(distinct),
+            )),
+        ),
+        |(_, g)| Command::ChooseCard(g),
+    )
+}
+
+pub fn choose_set_parser() -> impl Parser<T = Command> {
+    Map::new(
+        Chain2::new(
+            Doc::name_desc(
+                "choose",
+                "choose one of the two pairs to place on your side",
+                Token::new("choose"),
+            ),
+            AfterSpace::new(Doc::name_desc(
+                "set",
+                "the pair to take, 1 or 2",
+                Int::bounded(1, 2),
+            )),
+        ),
+        |(_, n)| Command::ChooseSet((n - 1) as usize),
+    )
+}

--- a/rust/game/hanamikoji-1/src/lib.rs
+++ b/rust/game/hanamikoji-1/src/lib.rs
@@ -1122,4 +1122,217 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, GameError::InvalidInput { .. }));
     }
+
+    fn legal_command(g: &Game) -> (usize, String) {
+        let player = g.whose_turn()[0];
+        match g.phase {
+            Phase::ChooseAction => {
+                let hand = &g.hands[player];
+                let used = g.used[player];
+                if !used[0] && !hand.is_empty() {
+                    (player, format!("secret {}", hand[0].name().to_lowercase()))
+                } else if !used[1] && hand.len() >= 2 {
+                    (
+                        player,
+                        format!(
+                            "trade {} {}",
+                            hand[0].name().to_lowercase(),
+                            hand[1].name().to_lowercase()
+                        ),
+                    )
+                } else if !used[2] && hand.len() >= 3 {
+                    (
+                        player,
+                        format!(
+                            "gift {} {} {}",
+                            hand[0].name().to_lowercase(),
+                            hand[1].name().to_lowercase(),
+                            hand[2].name().to_lowercase()
+                        ),
+                    )
+                } else if !used[3] && hand.len() >= 4 {
+                    (
+                        player,
+                        format!(
+                            "compete {} {} {} {}",
+                            hand[0].name().to_lowercase(),
+                            hand[1].name().to_lowercase(),
+                            hand[2].name().to_lowercase(),
+                            hand[3].name().to_lowercase()
+                        ),
+                    )
+                } else {
+                    panic!("no legal action available");
+                }
+            }
+            Phase::OpponentChoose => match g.pending.as_ref().expect("pending choice") {
+                Pending::Gift { cards, .. } => {
+                    (player, format!("choose {}", cards[0].name().to_lowercase()))
+                }
+                Pending::Competition { .. } => (player, "choose 1".to_string()),
+            },
+            Phase::Finished => panic!("game already finished"),
+        }
+    }
+
+    fn has_epilogue(logs: &[Log]) -> bool {
+        logs.iter()
+            .any(|l| brdgme_markup::to_string(&l.content).contains("Final scores:"))
+    }
+
+    fn drive_to_finish(g: &mut Game) -> (CommandResponse, Vec<Log>) {
+        let mut non_final: Vec<Log> = vec![];
+        let mut iterations = 0;
+        loop {
+            iterations += 1;
+            assert!(iterations < 200, "game did not terminate");
+            let (player, cmd) = legal_command(g);
+            let resp = g.command(player, &cmd, &names()).unwrap();
+            if g.is_finished() {
+                return (resp, non_final);
+            }
+            non_final.extend(resp.logs);
+        }
+    }
+
+    #[test]
+    fn test_play_full_game_to_finish() {
+        for seed in [1u64, 42, 999] {
+            let (mut g, _) = Game::start(2, seed).unwrap();
+            let mut iterations = 0;
+            while !g.is_finished() {
+                iterations += 1;
+                assert!(iterations < 200, "game did not terminate for seed {seed}");
+                let (player, cmd) = legal_command(&g);
+                g.command(player, &cmd, &names()).unwrap();
+            }
+            assert!(g.is_finished());
+            assert!(g.winner.is_some());
+            let mut placings = g.placings();
+            assert_eq!(2, placings.len());
+            placings.sort();
+            assert_eq!(vec![1, 2], placings);
+            assert!(g.validate().is_ok());
+        }
+    }
+
+    #[test]
+    fn test_finish_emits_epilogue_once() {
+        let (mut g, _) = Game::start(2, 5).unwrap();
+        let (final_resp, non_final) = drive_to_finish(&mut g);
+        assert!(has_epilogue(&final_resp.logs));
+        assert!(!has_epilogue(&non_final));
+    }
+
+    #[test]
+    fn test_command_parse_round_trips() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        let cur = g.current;
+        g.hands[cur] = vec![Geisha::Flute, Geisha::Koto, Geisha::Fan, Geisha::Tea];
+
+        let parse = |g: &Game, player: usize, input: &str| {
+            g.command_parser(player)
+                .expect("parser available")
+                .parse(input, &names())
+                .expect("parses")
+                .value
+        };
+
+        assert_eq!(
+            Command::Secret(Geisha::Flute),
+            parse(&g, cur, "secret flute")
+        );
+        assert_eq!(
+            Command::Trade(Geisha::Flute, Geisha::Koto),
+            parse(&g, cur, "trade flute koto")
+        );
+        assert_eq!(
+            Command::Gift(Geisha::Flute, Geisha::Koto, Geisha::Fan),
+            parse(&g, cur, "gift flute koto fan")
+        );
+        assert_eq!(
+            Command::Compete(Geisha::Flute, Geisha::Koto, Geisha::Fan, Geisha::Tea),
+            parse(&g, cur, "compete flute koto fan tea")
+        );
+
+        assert_eq!(
+            Command::Secret(Geisha::Flute),
+            parse(&g, cur, "SECRET FLUTE")
+        );
+        assert_eq!(
+            Command::Secret(Geisha::Flute),
+            parse(&g, cur, "Secret Flute")
+        );
+
+        let opp = 1 - cur;
+        g.phase = Phase::OpponentChoose;
+        g.pending = Some(Pending::Gift {
+            actor: cur,
+            cards: vec![Geisha::Flute, Geisha::Koto, Geisha::Fan],
+        });
+        assert_eq!(
+            Command::ChooseCard(Geisha::Flute),
+            parse(&g, opp, "choose flute")
+        );
+
+        g.pending = Some(Pending::Competition {
+            actor: cur,
+            sets: [
+                vec![Geisha::Flute, Geisha::Koto],
+                vec![Geisha::Fan, Geisha::Tea],
+            ],
+        });
+        assert_eq!(Command::ChooseSet(0), parse(&g, opp, "choose 1"));
+        assert_eq!(Command::ChooseSet(1), parse(&g, opp, "choose 2"));
+    }
+
+    #[test]
+    fn test_command_spec_availability() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        let cur = g.current;
+        assert!(g.command_spec(cur).is_some());
+        assert!(g.command_spec(1 - cur).is_none());
+
+        g.winner = Some(0);
+        assert!(g.command_spec(0).is_none());
+        assert!(g.command_spec(1).is_none());
+    }
+
+    #[test]
+    fn test_marker_persists_across_rounds() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        g.faceup = vec![[0, 0]; GEISHA];
+        g.faceup[0] = [1, 0];
+        g.secret = vec![None, None];
+        let old_round = g.round;
+        g.score_round();
+        assert!(g.winner.is_none());
+        assert_eq!(old_round + 1, g.round);
+        assert_eq!(Some(0), g.marker[0]);
+        for f in &g.faceup {
+            assert_eq!([0, 0], *f);
+        }
+    }
+
+    #[test]
+    fn test_multibyte_and_hostile_input() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        let cur = g.current;
+        g.hands[cur] = vec![Geisha::Tea, Geisha::Taiko];
+        let hostile = [
+            "\u{a0}secret",
+            "secret\u{a0}flute",
+            "secret \u{3000}flute",
+            "secret caf\u{e9}",
+            "secret \u{1f004}",
+            "e\u{301}",
+        ];
+        for input in hostile {
+            let result = g.command(cur, input, &names());
+            assert!(
+                matches!(result, Err(GameError::InvalidInput { .. })),
+                "expected InvalidInput for {input:?}"
+            );
+        }
+    }
 }

--- a/rust/game/hanamikoji-1/src/lib.rs
+++ b/rust/game/hanamikoji-1/src/lib.rs
@@ -1,0 +1,1125 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+pub mod card;
+mod command;
+mod render;
+
+use brdgme_color::NamedColor;
+use brdgme_game::command::Spec as CommandSpec;
+use brdgme_game::command::parser::Output as ParseOutput;
+use brdgme_game::errors::GameError;
+use brdgme_game::game::gen_placings;
+use brdgme_game::rng::GameRng;
+use brdgme_game::{CommandResponse, Gamer, Log, Stat, Status, placings_log};
+use brdgme_markup::Node as N;
+use rand::prelude::*;
+use rand::seq::SliceRandom;
+
+use crate::card::Geisha;
+use crate::command::Command;
+
+const GEISHA: usize = 7;
+const WIN_GEISHA: usize = 4;
+const WIN_CHARM: i32 = 11;
+
+#[derive(Default, PartialEq, Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum Phase {
+    #[default]
+    ChooseAction,
+    OpponentChoose,
+    Finished,
+}
+
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+pub enum Pending {
+    Gift {
+        actor: usize,
+        cards: Vec<Geisha>,
+    },
+    Competition {
+        actor: usize,
+        sets: [Vec<Geisha>; 2],
+    },
+}
+
+#[derive(Default, PartialEq, Debug, Clone, Serialize, Deserialize)]
+pub struct Game {
+    players: usize,
+    marker: Vec<Option<usize>>,
+    faceup: Vec<[u32; 2]>,
+    hands: Vec<Vec<Geisha>>,
+    secret: Vec<Option<Geisha>>,
+    traded: Vec<Vec<Geisha>>,
+    used: Vec<[bool; 4]>,
+    deck: Vec<Geisha>,
+    round: u32,
+    starting: usize,
+    current: usize,
+    phase: Phase,
+    pending: Option<Pending>,
+    winner: Option<usize>,
+    #[serde(default = "GameRng::from_entropy")]
+    rng: GameRng,
+}
+
+/// Spectator view. Structurally omits hidden info: the deck order, hand
+/// contents, secret contents and trade-off contents are simply not present -
+/// only counts and public consequences (face-up cards, victory markers and the
+/// face-up pending choice) are exposed.
+#[derive(Default, Serialize, Deserialize)]
+pub struct PubState {
+    /// Number of players (always 2).
+    pub players: usize,
+    /// The current round number.
+    pub round: u32,
+    /// True once a winner has been decided.
+    pub finished: bool,
+    /// Which step of the turn the game is in.
+    pub phase: Phase,
+    /// The actor of the current real turn.
+    pub current: usize,
+    /// The player(s) expected to act next.
+    pub whose_turn: Vec<usize>,
+    /// The player who starts this round.
+    pub starting: usize,
+    /// Cards left in the draw pile (order hidden).
+    pub deck_remaining: usize,
+    /// Victory marker position per geisha: None = contested, Some(p) = controlled by p.
+    pub marker: Vec<Option<usize>>,
+    /// Face-up card counts per geisha per player.
+    pub faceup: Vec<[u32; 2]>,
+    /// Which of the four action markers each player has used this round.
+    pub used: Vec<[bool; 4]>,
+    /// Number of cards in each player's hand (contents hidden).
+    pub hand_counts: Vec<usize>,
+    /// Whether each player has a face-down secret card (identity hidden).
+    pub has_secret: Vec<bool>,
+    /// Number of cards each player has set aside for trade-off (identities hidden).
+    pub traded_counts: Vec<usize>,
+    /// The face-up pending choice, if any (gift cards or competition sets).
+    pub pending: Option<Pending>,
+    /// Number of geisha each player currently controls.
+    pub geisha_counts: Vec<usize>,
+    /// Charm points each player currently controls.
+    pub charms: Vec<i32>,
+    /// The winner, if the game is over.
+    pub winner: Option<usize>,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct PlayerState {
+    /// The full public game state.
+    pub public: PubState,
+    /// Which player this private state belongs to.
+    pub player: usize,
+    /// This player's hand.
+    pub hand: Vec<Geisha>,
+    /// This player's face-down secret card, if any.
+    pub secret: Option<Geisha>,
+    /// This player's face-down trade-off discard.
+    pub traded: Vec<Geisha>,
+}
+
+impl Game {
+    fn sort_hand(&mut self, player: usize) {
+        if let Some(hand) = self.hands.get_mut(player) {
+            hand.sort_by_key(|g| g.index());
+        }
+    }
+
+    fn can_remove(&self, player: usize, cards: &[Geisha]) -> bool {
+        let hand = match self.hands.get(player) {
+            Some(hand) => hand,
+            None => return false,
+        };
+        let mut need = [0i32; GEISHA];
+        for c in cards {
+            need[c.index()] += 1;
+        }
+        let mut have = [0i32; GEISHA];
+        for c in hand {
+            have[c.index()] += 1;
+        }
+        (0..GEISHA).all(|i| have[i] >= need[i])
+    }
+
+    fn remove_from_hand(&mut self, player: usize, geisha: Geisha) -> bool {
+        let Some(hand) = self.hands.get_mut(player) else {
+            return false;
+        };
+        let Some(pos) = hand.iter().position(|c| *c == geisha) else {
+            return false;
+        };
+        hand.remove(pos);
+        true
+    }
+
+    fn remove_cards(&mut self, player: usize, cards: &[Geisha]) {
+        for c in cards {
+            self.remove_from_hand(player, *c);
+        }
+    }
+
+    fn geisha_counts(&self) -> [usize; 2] {
+        let mut counts = [0usize; 2];
+        for m in &self.marker {
+            if let Some(p) = m
+                && *p < 2
+            {
+                counts[*p] += 1;
+            }
+        }
+        counts
+    }
+
+    fn charms(&self) -> [i32; 2] {
+        let mut counts = [0i32; 2];
+        for (i, m) in self.marker.iter().enumerate() {
+            if let Some(p) = m
+                && *p < 2
+                && let Some(g) = Geisha::ALL.get(i)
+            {
+                counts[*p] += g.charm();
+            }
+        }
+        counts
+    }
+
+    fn whose_turn_calc(&self) -> Vec<usize> {
+        match self.phase {
+            Phase::ChooseAction => vec![self.current],
+            Phase::OpponentChoose => vec![1 - self.current],
+            Phase::Finished => vec![],
+        }
+    }
+
+    fn deal_round(&mut self) {
+        let mut pool = Geisha::full_deck();
+        pool.shuffle(&mut self.rng);
+        pool.pop();
+        self.hands = vec![vec![]; self.players];
+        for _ in 0..6 {
+            if let Some(c) = pool.pop() {
+                self.hands[0].push(c);
+            }
+        }
+        for _ in 0..6 {
+            if let Some(c) = pool.pop() {
+                self.hands[1].push(c);
+            }
+        }
+        for p in 0..self.players {
+            self.sort_hand(p);
+        }
+        self.deck = pool;
+        self.secret = vec![None; self.players];
+        self.traded = vec![vec![]; self.players];
+    }
+
+    fn begin_turn(&mut self, player: usize) -> Vec<Log> {
+        let mut logs = vec![];
+        if let Some(card) = self.deck.pop() {
+            if let Some(hand) = self.hands.get_mut(player) {
+                hand.push(card);
+            }
+            self.sort_hand(player);
+            logs.push(Log::public(vec![
+                N::Player(player),
+                N::text(" drew a card, "),
+                N::Bold(vec![N::text(self.deck.len().to_string())]),
+                N::text(" remaining in the deck"),
+            ]));
+            logs.push(Log::private(
+                vec![N::text("You drew "), render::geisha_node(card)],
+                vec![player],
+            ));
+        }
+        self.current = player;
+        self.phase = Phase::ChooseAction;
+        logs.push(Log::public(vec![
+            N::text("It is "),
+            N::Player(player),
+            N::text("'s turn"),
+        ]));
+        logs
+    }
+
+    fn advance_turn(&mut self) -> Vec<Log> {
+        let all_used = (0..self.players).all(|p| {
+            self.used
+                .get(p)
+                .copied()
+                .unwrap_or([false; 4])
+                .iter()
+                .all(|u| *u)
+        });
+        if all_used {
+            self.score_round()
+        } else {
+            self.begin_turn(1 - self.current)
+        }
+    }
+
+    fn decide_winner(geisha: &[usize; 2], charm: &[i32; 2]) -> Option<usize> {
+        let reaches = |p: usize| geisha[p] >= WIN_GEISHA || charm[p] >= WIN_CHARM;
+        match (reaches(0), reaches(1)) {
+            (false, false) => None,
+            (true, false) => Some(0),
+            (false, true) => Some(1),
+            // Both reached a goal: the rulebook awards it to the player who
+            // reached 11+ charm. Only one can (charm sums to 21), so this is
+            // unambiguous; the fallback is defensive only.
+            (true, true) => Some(if charm[0] >= WIN_CHARM { 0 } else { 1 }),
+        }
+    }
+
+    fn score_round(&mut self) -> Vec<Log> {
+        let mut logs = vec![];
+        for p in 0..self.players {
+            if let Some(g) = self.secret.get(p).copied().flatten() {
+                if let Some(f) = self.faceup.get_mut(g.index()) {
+                    f[p] += 1;
+                }
+                logs.push(Log::public(vec![
+                    N::Player(p),
+                    N::text(" revealed a secret "),
+                    render::geisha_node(g),
+                ]));
+            }
+        }
+        for i in 0..self.marker.len() {
+            let f = self.faceup.get(i).copied().unwrap_or([0, 0]);
+            if f[0] > f[1] {
+                self.marker[i] = Some(0);
+            } else if f[1] > f[0] {
+                self.marker[i] = Some(1);
+            }
+        }
+        self.secret = vec![None; self.players];
+
+        let geisha = self.geisha_counts();
+        let charm = self.charms();
+
+        let mut summary: Vec<N> = vec![N::Bold(vec![N::text(format!(
+            "Round {} scored",
+            self.round
+        ))])];
+        for g in Geisha::ALL {
+            summary.push(N::text("\n  "));
+            summary.push(render::geisha_node(g));
+            summary.push(N::text(format!(" ({}): ", g.charm())));
+            match self.marker.get(g.index()).copied().unwrap_or(None) {
+                Some(p) => summary.push(N::Player(p)),
+                None => summary.push(N::Fg(NamedColor::Grey.into(), vec![N::text("contested")])),
+            }
+        }
+        summary.push(N::text("\n"));
+        summary.push(N::Player(0));
+        summary.push(N::text(format!(
+            " controls {} geisha ({} charm), ",
+            geisha[0], charm[0]
+        )));
+        summary.push(N::Player(1));
+        summary.push(N::text(format!(
+            " controls {} geisha ({} charm)",
+            geisha[1], charm[1]
+        )));
+        logs.push(Log::public(summary));
+
+        if let Some(w) = Self::decide_winner(&geisha, &charm) {
+            self.winner = Some(w);
+            self.phase = Phase::Finished;
+            logs.push(Log::public(vec![
+                N::Bold(vec![N::text("Game over - ")]),
+                N::Player(w),
+                N::Bold(vec![N::text(" wins!")]),
+            ]));
+        } else {
+            self.used = vec![[false; 4]; self.players];
+            self.faceup = vec![[0, 0]; self.marker.len()];
+            self.starting = 1 - self.starting;
+            self.round += 1;
+            self.deal_round();
+            logs.push(Log::public(vec![
+                N::Bold(vec![N::text(format!("Round {} begins", self.round))]),
+                N::text(" - "),
+                N::Player(self.starting),
+                N::text(" goes first"),
+            ]));
+            logs.extend(self.begin_turn(self.starting));
+        }
+        logs
+    }
+
+    fn assert_action(&self, player: usize) -> Result<(), GameError> {
+        self.assert_not_finished()?;
+        if self.phase != Phase::ChooseAction {
+            return Err(GameError::invalid_input(
+                "you must wait for the pending choice to be resolved",
+            ));
+        }
+        if self.current != player {
+            return Err(GameError::NotYourTurn);
+        }
+        Ok(())
+    }
+
+    fn already_used(&self, player: usize, action: usize) -> bool {
+        self.used.get(player).map(|u| u[action]).unwrap_or(true)
+    }
+
+    fn secret(&mut self, player: usize, geisha: Geisha) -> Result<Vec<Log>, GameError> {
+        self.assert_action(player)?;
+        if self.already_used(player, 0) {
+            return Err(GameError::invalid_input(
+                "you have already used your secret action this round",
+            ));
+        }
+        if !self.can_remove(player, &[geisha]) {
+            return Err(GameError::invalid_input(
+                "you do not have that card in your hand",
+            ));
+        }
+        self.remove_cards(player, &[geisha]);
+        if let Some(s) = self.secret.get_mut(player) {
+            *s = Some(geisha);
+        }
+        if let Some(u) = self.used.get_mut(player) {
+            u[0] = true;
+        }
+        let mut logs = vec![
+            Log::public(vec![
+                N::Player(player),
+                N::text(" played a "),
+                N::Bold(vec![N::text("secret")]),
+                N::text(" card"),
+            ]),
+            Log::private(
+                vec![
+                    N::text("You played "),
+                    render::geisha_node(geisha),
+                    N::text(" as your secret card"),
+                ],
+                vec![player],
+            ),
+        ];
+        logs.extend(self.advance_turn());
+        Ok(logs)
+    }
+
+    fn trade(&mut self, player: usize, a: Geisha, b: Geisha) -> Result<Vec<Log>, GameError> {
+        self.assert_action(player)?;
+        if self.already_used(player, 1) {
+            return Err(GameError::invalid_input(
+                "you have already used your trade-off action this round",
+            ));
+        }
+        if !self.can_remove(player, &[a, b]) {
+            return Err(GameError::invalid_input(
+                "you do not have those cards in your hand",
+            ));
+        }
+        self.remove_cards(player, &[a, b]);
+        if let Some(t) = self.traded.get_mut(player) {
+            t.push(a);
+            t.push(b);
+        }
+        if let Some(u) = self.used.get_mut(player) {
+            u[1] = true;
+        }
+        let mut logs = vec![
+            Log::public(vec![
+                N::Player(player),
+                N::text(" set aside two cards for a "),
+                N::Bold(vec![N::text("trade-off")]),
+            ]),
+            Log::private(
+                vec![
+                    N::text("You set aside "),
+                    render::geisha_node(a),
+                    N::text(" and "),
+                    render::geisha_node(b),
+                ],
+                vec![player],
+            ),
+        ];
+        logs.extend(self.advance_turn());
+        Ok(logs)
+    }
+
+    fn gift(&mut self, player: usize, cards: [Geisha; 3]) -> Result<Vec<Log>, GameError> {
+        self.assert_action(player)?;
+        if self.already_used(player, 2) {
+            return Err(GameError::invalid_input(
+                "you have already used your gift action this round",
+            ));
+        }
+        if !self.can_remove(player, &cards) {
+            return Err(GameError::invalid_input(
+                "you do not have those cards in your hand",
+            ));
+        }
+        self.remove_cards(player, &cards);
+        self.pending = Some(Pending::Gift {
+            actor: player,
+            cards: cards.to_vec(),
+        });
+        self.phase = Phase::OpponentChoose;
+        let mut line = vec![
+            N::Player(player),
+            N::text(" played a "),
+            N::Bold(vec![N::text("gift")]),
+            N::text(" offering "),
+        ];
+        line.extend(render::comma_geisha(&cards));
+        line.push(N::text("; "));
+        line.push(N::Player(1 - player));
+        line.push(N::text(" chooses one"));
+        Ok(vec![Log::public(line)])
+    }
+
+    fn compete(&mut self, player: usize, cards: [Geisha; 4]) -> Result<Vec<Log>, GameError> {
+        self.assert_action(player)?;
+        if self.already_used(player, 3) {
+            return Err(GameError::invalid_input(
+                "you have already used your competition action this round",
+            ));
+        }
+        if !self.can_remove(player, &cards) {
+            return Err(GameError::invalid_input(
+                "you do not have those cards in your hand",
+            ));
+        }
+        self.remove_cards(player, &cards);
+        let sets = [vec![cards[0], cards[1]], vec![cards[2], cards[3]]];
+        self.pending = Some(Pending::Competition {
+            actor: player,
+            sets: sets.clone(),
+        });
+        self.phase = Phase::OpponentChoose;
+        let mut line = vec![
+            N::Player(player),
+            N::text(" played a "),
+            N::Bold(vec![N::text("competition")]),
+            N::text(" offering set 1 { "),
+        ];
+        line.extend(render::comma_geisha(&sets[0]));
+        line.push(N::text(" } and set 2 { "));
+        line.extend(render::comma_geisha(&sets[1]));
+        line.push(N::text(" }; "));
+        line.push(N::Player(1 - player));
+        line.push(N::text(" chooses a set"));
+        Ok(vec![Log::public(line)])
+    }
+
+    fn choose_gift(&mut self, player: usize, geisha: Geisha) -> Result<Vec<Log>, GameError> {
+        self.assert_not_finished()?;
+        if self.phase != Phase::OpponentChoose {
+            return Err(GameError::invalid_input(
+                "there is no pending choice to make",
+            ));
+        }
+        let (actor, cards) = match self.pending.clone() {
+            Some(Pending::Gift { actor, cards }) => (actor, cards),
+            _ => {
+                return Err(GameError::invalid_input("there is no gift to choose from"));
+            }
+        };
+        if player != 1 - actor {
+            return Err(GameError::NotYourTurn);
+        }
+        if !cards.contains(&geisha) {
+            return Err(GameError::invalid_input(
+                "that card is not part of the gift",
+            ));
+        }
+        let mut others = cards;
+        if let Some(pos) = others.iter().position(|c| *c == geisha) {
+            others.remove(pos);
+        }
+        if let Some(f) = self.faceup.get_mut(geisha.index()) {
+            f[player] += 1;
+        }
+        for c in &others {
+            if let Some(f) = self.faceup.get_mut(c.index()) {
+                f[actor] += 1;
+            }
+        }
+        if let Some(u) = self.used.get_mut(actor) {
+            u[2] = true;
+        }
+        self.pending = None;
+        let mut logs = vec![Log::public(vec![
+            N::Player(player),
+            N::text(" took "),
+            render::geisha_node(geisha),
+            N::text(" from the gift; "),
+            N::Player(actor),
+            N::text(" placed the rest"),
+        ])];
+        logs.extend(self.advance_turn());
+        Ok(logs)
+    }
+
+    fn choose_competition(&mut self, player: usize, set_idx: usize) -> Result<Vec<Log>, GameError> {
+        self.assert_not_finished()?;
+        if self.phase != Phase::OpponentChoose {
+            return Err(GameError::invalid_input(
+                "there is no pending choice to make",
+            ));
+        }
+        let (actor, sets) = match self.pending.clone() {
+            Some(Pending::Competition { actor, sets }) => (actor, sets),
+            _ => {
+                return Err(GameError::invalid_input(
+                    "there is no competition to choose from",
+                ));
+            }
+        };
+        if player != 1 - actor {
+            return Err(GameError::NotYourTurn);
+        }
+        if set_idx >= 2 {
+            return Err(GameError::invalid_input("choose set 1 or set 2"));
+        }
+        for c in &sets[set_idx] {
+            if let Some(f) = self.faceup.get_mut(c.index()) {
+                f[player] += 1;
+            }
+        }
+        for c in &sets[1 - set_idx] {
+            if let Some(f) = self.faceup.get_mut(c.index()) {
+                f[actor] += 1;
+            }
+        }
+        if let Some(u) = self.used.get_mut(actor) {
+            u[3] = true;
+        }
+        self.pending = None;
+        let mut logs = vec![Log::public(vec![
+            N::Player(player),
+            N::text(" took set "),
+            N::Bold(vec![N::text((set_idx + 1).to_string())]),
+            N::text(" from the competition; "),
+            N::Player(actor),
+            N::text(" placed the other"),
+        ])];
+        logs.extend(self.advance_turn());
+        Ok(logs)
+    }
+
+    fn placings(&self) -> Vec<usize> {
+        let mut metrics = vec![vec![0i32]; self.players];
+        if let Some(w) = self.winner
+            && w < self.players
+        {
+            metrics[w] = vec![1];
+        }
+        gen_placings(&metrics)
+    }
+
+    fn finished_stats(&self) -> Vec<HashMap<String, Stat>> {
+        let geisha = self.geisha_counts();
+        let charm = self.charms();
+        (0..self.players)
+            .map(|p| {
+                let mut m = HashMap::new();
+                m.insert("geisha".to_string(), Stat::Int(geisha[p] as i32));
+                m.insert("charm".to_string(), Stat::Int(charm[p]));
+                m
+            })
+            .collect()
+    }
+}
+
+impl Gamer for Game {
+    type PubState = PubState;
+    type PlayerState = PlayerState;
+
+    fn start(players: usize, seed: u64) -> Result<(Self, Vec<Log>), GameError> {
+        if players != 2 {
+            return Err(GameError::PlayerCount {
+                min: 2,
+                max: 2,
+                given: players,
+            });
+        }
+        let mut g = Game {
+            players: 2,
+            marker: vec![None; GEISHA],
+            faceup: vec![[0, 0]; GEISHA],
+            hands: vec![vec![]; 2],
+            secret: vec![None; 2],
+            traded: vec![vec![]; 2],
+            used: vec![[false; 4]; 2],
+            round: 1,
+            rng: GameRng::seed_from_u64(seed),
+            ..Game::default()
+        };
+        g.starting = g.rng.random_range(0..2);
+        let mut logs = vec![Log::public(vec![
+            N::Bold(vec![N::text("A new game of Hanamikoji started")]),
+            N::text(" - "),
+            N::Player(g.starting),
+            N::text(" goes first"),
+        ])];
+        g.deal_round();
+        logs.extend(g.begin_turn(g.starting));
+        Ok((g, logs))
+    }
+
+    fn validate(&self) -> Result<(), GameError> {
+        if self.players != 2 {
+            return Err(GameError::internal("hanamikoji-1: players must be 2"));
+        }
+        if self.hands.len() != 2 {
+            return Err(GameError::internal("hanamikoji-1: hands length mismatch"));
+        }
+        if self.secret.len() != 2 {
+            return Err(GameError::internal("hanamikoji-1: secret length mismatch"));
+        }
+        if self.traded.len() != 2 {
+            return Err(GameError::internal("hanamikoji-1: traded length mismatch"));
+        }
+        if self.used.len() != 2 {
+            return Err(GameError::internal("hanamikoji-1: used length mismatch"));
+        }
+        if self.marker.len() != GEISHA {
+            return Err(GameError::internal("hanamikoji-1: marker length mismatch"));
+        }
+        if self.faceup.len() != GEISHA {
+            return Err(GameError::internal("hanamikoji-1: faceup length mismatch"));
+        }
+        for m in &self.marker {
+            if let Some(p) = m
+                && *p >= 2
+            {
+                return Err(GameError::internal(
+                    "hanamikoji-1: marker owner out of range",
+                ));
+            }
+        }
+        if self.current >= 2 {
+            return Err(GameError::internal("hanamikoji-1: current out of range"));
+        }
+        if self.starting >= 2 {
+            return Err(GameError::internal("hanamikoji-1: starting out of range"));
+        }
+        if self.winner.is_some_and(|w| w >= 2) {
+            return Err(GameError::internal("hanamikoji-1: winner out of range"));
+        }
+        if let Some(pending) = &self.pending {
+            match pending {
+                Pending::Gift { actor, cards } => {
+                    if *actor >= 2 || cards.is_empty() {
+                        return Err(GameError::internal("hanamikoji-1: inconsistent gift"));
+                    }
+                }
+                Pending::Competition { actor, sets } => {
+                    if *actor >= 2 || sets[0].is_empty() || sets[1].is_empty() {
+                        return Err(GameError::internal(
+                            "hanamikoji-1: inconsistent competition",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn status(&self) -> Status {
+        if self.winner.is_some() {
+            Status::Finished {
+                placings: self.placings(),
+                stats: self.finished_stats(),
+            }
+        } else {
+            Status::Active {
+                whose_turn: self.whose_turn_calc(),
+                eliminated: vec![],
+            }
+        }
+    }
+
+    fn pub_state(&self) -> Self::PubState {
+        let geisha = self.geisha_counts();
+        let charm = self.charms();
+        PubState {
+            players: self.players,
+            round: self.round,
+            finished: self.winner.is_some(),
+            phase: self.phase,
+            current: self.current,
+            whose_turn: self.whose_turn_calc(),
+            starting: self.starting,
+            deck_remaining: self.deck.len(),
+            marker: self.marker.clone(),
+            faceup: self.faceup.clone(),
+            used: self.used.clone(),
+            hand_counts: self.hands.iter().map(|h| h.len()).collect(),
+            has_secret: self.secret.iter().map(|s| s.is_some()).collect(),
+            traded_counts: self.traded.iter().map(|t| t.len()).collect(),
+            pending: self.pending.clone(),
+            geisha_counts: geisha.to_vec(),
+            charms: charm.to_vec(),
+            winner: self.winner,
+        }
+    }
+
+    fn player_state(&self, player: usize) -> Self::PlayerState {
+        PlayerState {
+            public: self.pub_state(),
+            player,
+            hand: self.hands.get(player).cloned().unwrap_or_default(),
+            secret: self.secret.get(player).copied().flatten(),
+            traded: self.traded.get(player).cloned().unwrap_or_default(),
+        }
+    }
+
+    fn command(
+        &mut self,
+        player: usize,
+        input: &str,
+        players: &[String],
+    ) -> Result<CommandResponse, GameError> {
+        let output = match self.command_parser(player) {
+            Some(cp) => cp,
+            None => {
+                return Err(GameError::invalid_input(
+                    "not expecting any commands at the moment",
+                ));
+            }
+        }
+        .parse(input, players);
+        let was_finished = self.is_finished();
+        let (mut logs, remaining_input) = match output {
+            Ok(ParseOutput {
+                value: Command::Secret(g),
+                remaining,
+                ..
+            }) => (self.secret(player, g)?, remaining.to_string()),
+            Ok(ParseOutput {
+                value: Command::Trade(a, b),
+                remaining,
+                ..
+            }) => (self.trade(player, a, b)?, remaining.to_string()),
+            Ok(ParseOutput {
+                value: Command::Gift(a, b, c),
+                remaining,
+                ..
+            }) => (self.gift(player, [a, b, c])?, remaining.to_string()),
+            Ok(ParseOutput {
+                value: Command::Compete(a, b, c, d),
+                remaining,
+                ..
+            }) => (self.compete(player, [a, b, c, d])?, remaining.to_string()),
+            Ok(ParseOutput {
+                value: Command::ChooseCard(g),
+                remaining,
+                ..
+            }) => (self.choose_gift(player, g)?, remaining.to_string()),
+            Ok(ParseOutput {
+                value: Command::ChooseSet(i),
+                remaining,
+                ..
+            }) => (self.choose_competition(player, i)?, remaining.to_string()),
+            Err(e) => return Err(GameError::invalid_input(e.to_string())),
+        };
+        if !was_finished && self.is_finished() {
+            let charm = self.charms();
+            let scores: Vec<(usize, i32)> = (0..self.players).map(|p| (p, charm[p])).collect();
+            logs.push(placings_log(&self.placings(), Some(&scores)));
+        }
+        Ok(CommandResponse {
+            logs,
+            can_undo: false,
+            remaining_input,
+        })
+    }
+
+    fn command_spec(&self, player: usize) -> Option<CommandSpec> {
+        self.command_parser(player).map(|cp| cp.to_spec())
+    }
+
+    fn points(&self) -> Vec<f32> {
+        match self.winner {
+            Some(w) => (0..self.players)
+                .map(|p| if p == w { 1.0 } else { 0.0 })
+                .collect(),
+            None => vec![0.0; self.players],
+        }
+    }
+
+    fn player_counts() -> Vec<usize> {
+        vec![2]
+    }
+
+    fn player_count(&self) -> usize {
+        self.players
+    }
+
+    fn rules() -> String {
+        include_str!("../RULES.md").to_string()
+    }
+
+    fn data_docs() -> String {
+        include_str!("../DATA_DOCS.md").to_string()
+    }
+
+    fn basic_strategy() -> String {
+        include_str!("../BASIC_STRATEGY.md").to_string()
+    }
+
+    fn advanced_strategy() -> String {
+        include_str!("../ADVANCED_STRATEGY.md").to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names() -> Vec<String> {
+        vec!["player0".to_string(), "player1".to_string()]
+    }
+
+    #[test]
+    fn test_full_deck() {
+        let deck = Geisha::full_deck();
+        assert_eq!(21, deck.len());
+        for g in Geisha::ALL {
+            assert_eq!(3, deck.iter().filter(|c| **c == g).count());
+        }
+    }
+
+    #[test]
+    fn test_charm_sum() {
+        let total: i32 = Geisha::ALL.iter().map(|g| g.charm()).sum();
+        assert_eq!(21, total);
+    }
+
+    #[test]
+    fn test_start_wrong_player_count() {
+        assert!(matches!(
+            Game::start(3, 1),
+            Err(GameError::PlayerCount { .. })
+        ));
+        assert!(Game::start(2, 1).is_ok());
+    }
+
+    #[test]
+    fn test_start_deals() {
+        let (g, _) = Game::start(2, 1).unwrap();
+        assert_eq!(1, g.round);
+        assert_eq!(7, g.deck.len());
+        assert_eq!(7, g.hands[g.starting].len());
+        assert_eq!(6, g.hands[1 - g.starting].len());
+        assert!(g.starting < 2);
+        assert_eq!(g.starting, g.current);
+    }
+
+    #[test]
+    fn test_start_is_deterministic() {
+        let (a, _) = Game::start(2, 7).unwrap();
+        let (b, _) = Game::start(2, 7).unwrap();
+        assert_eq!(a.hands, b.hands);
+        assert_eq!(a.deck, b.deck);
+        assert_eq!(a.starting, b.starting);
+    }
+
+    #[test]
+    fn test_whose_turn() {
+        let (g, _) = Game::start(2, 1).unwrap();
+        assert_eq!(vec![g.current], g.whose_turn());
+    }
+
+    #[test]
+    fn test_secret_action() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        let cur = g.current;
+        let card = g.hands[cur][0];
+        let before = g.hands[cur].len();
+        g.secret(cur, card).unwrap();
+        assert_eq!(Some(card), g.secret[cur]);
+        assert!(g.used[cur][0]);
+        assert_eq!(before - 1, g.hands[cur].len());
+        assert_ne!(cur, g.current);
+    }
+
+    #[test]
+    fn test_trade_action() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        let cur = g.current;
+        g.hands[cur] = vec![Geisha::Flute, Geisha::Koto, Geisha::Fan];
+        g.trade(cur, Geisha::Flute, Geisha::Koto).unwrap();
+        assert!(g.used[cur][1]);
+        assert_eq!(vec![Geisha::Flute, Geisha::Koto], g.traded[cur]);
+        assert_eq!(vec![Geisha::Fan], g.hands[cur]);
+    }
+
+    #[test]
+    fn test_cannot_reuse_action() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        let cur = g.current;
+        g.hands[cur] = vec![Geisha::Flute, Geisha::Koto];
+        g.used[cur][0] = true;
+        assert!(g.secret(cur, Geisha::Flute).is_err());
+    }
+
+    #[test]
+    fn test_gift_command_flow() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        let actor = g.current;
+        let opp = 1 - actor;
+        g.hands[actor] = vec![Geisha::Flute, Geisha::Koto, Geisha::Fan, Geisha::Tea];
+        g.command(actor, "gift flute koto fan", &names()).unwrap();
+        assert_eq!(Phase::OpponentChoose, g.phase);
+        assert!(matches!(g.pending, Some(Pending::Gift { .. })));
+        g.command(opp, "choose flute", &names()).unwrap();
+        assert_eq!(1, g.faceup[Geisha::Flute.index()][opp]);
+        assert_eq!(1, g.faceup[Geisha::Koto.index()][actor]);
+        assert_eq!(1, g.faceup[Geisha::Fan.index()][actor]);
+        assert!(g.used[actor][2]);
+        assert!(g.pending.is_none());
+    }
+
+    #[test]
+    fn test_competition_command_flow() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        let actor = g.current;
+        let opp = 1 - actor;
+        g.hands[actor] = vec![
+            Geisha::Flute,
+            Geisha::Koto,
+            Geisha::Fan,
+            Geisha::Tea,
+            Geisha::Taiko,
+        ];
+        g.command(actor, "compete flute koto fan tea", &names())
+            .unwrap();
+        assert_eq!(Phase::OpponentChoose, g.phase);
+        assert!(matches!(g.pending, Some(Pending::Competition { .. })));
+        g.command(opp, "choose 2", &names()).unwrap();
+        assert_eq!(1, g.faceup[Geisha::Fan.index()][opp]);
+        assert_eq!(1, g.faceup[Geisha::Tea.index()][opp]);
+        assert_eq!(1, g.faceup[Geisha::Flute.index()][actor]);
+        assert_eq!(1, g.faceup[Geisha::Koto.index()][actor]);
+        assert!(g.used[actor][3]);
+        assert!(g.pending.is_none());
+    }
+
+    #[test]
+    fn test_decide_winner_geisha() {
+        assert_eq!(Some(0), Game::decide_winner(&[4, 3], &[10, 10]));
+        assert_eq!(Some(1), Game::decide_winner(&[3, 4], &[10, 10]));
+    }
+
+    #[test]
+    fn test_decide_winner_charm() {
+        assert_eq!(Some(0), Game::decide_winner(&[3, 3], &[11, 10]));
+        assert_eq!(Some(1), Game::decide_winner(&[3, 3], &[10, 11]));
+    }
+
+    #[test]
+    fn test_decide_winner_charm_beats_geisha() {
+        assert_eq!(Some(1), Game::decide_winner(&[4, 3], &[10, 11]));
+        assert_eq!(Some(0), Game::decide_winner(&[3, 4], &[11, 10]));
+    }
+
+    #[test]
+    fn test_decide_winner_none() {
+        assert_eq!(None, Game::decide_winner(&[3, 3], &[10, 10]));
+    }
+
+    #[test]
+    fn test_score_round_win() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        g.faceup = vec![[0, 0]; GEISHA];
+        g.faceup[0] = [1, 0];
+        g.faceup[1] = [1, 0];
+        g.faceup[2] = [1, 0];
+        g.faceup[3] = [1, 0];
+        g.secret = vec![None, None];
+        g.score_round();
+        assert_eq!(Some(0), g.winner);
+        assert_eq!(Phase::Finished, g.phase);
+        assert!(g.is_finished());
+        assert_eq!(vec![1, 2], g.placings());
+    }
+
+    #[test]
+    fn test_score_round_no_winner_starts_new_round() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        g.faceup = vec![[0, 0]; GEISHA];
+        g.faceup[0] = [1, 1];
+        g.secret = vec![None, None];
+        let old_starting = g.starting;
+        let old_round = g.round;
+        g.score_round();
+        assert!(g.winner.is_none());
+        assert_eq!(old_round + 1, g.round);
+        assert_eq!(1 - old_starting, g.starting);
+        assert_eq!(Phase::ChooseAction, g.phase);
+        assert_eq!(g.starting, g.current);
+    }
+
+    #[test]
+    fn test_secret_revealed_on_scoring() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        g.faceup = vec![[0, 0]; GEISHA];
+        g.secret = vec![Some(Geisha::Tea), None];
+        g.score_round();
+        assert_eq!(Some(0), g.marker[Geisha::Tea.index()]);
+        assert_eq!(vec![None, None], g.secret);
+    }
+
+    #[test]
+    fn test_validate() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        assert!(g.validate().is_ok());
+
+        g.current = 2;
+        assert!(matches!(g.validate(), Err(GameError::Internal { .. })));
+        g.current = 0;
+
+        g.marker.push(None);
+        assert!(matches!(g.validate(), Err(GameError::Internal { .. })));
+        g.marker.pop();
+
+        g.hands.push(vec![]);
+        assert!(matches!(g.validate(), Err(GameError::Internal { .. })));
+        g.hands.pop();
+
+        g.players = 3;
+        assert!(matches!(g.validate(), Err(GameError::Internal { .. })));
+        g.players = 2;
+
+        g.winner = Some(5);
+        assert!(matches!(g.validate(), Err(GameError::Internal { .. })));
+    }
+
+    #[test]
+    fn test_redaction() {
+        let (g, _) = Game::start(2, 1).unwrap();
+        let ps = g.pub_state();
+        let mut counts = ps.hand_counts.clone();
+        counts.sort();
+        assert_eq!(vec![6, 7], counts);
+        assert_eq!(7, ps.deck_remaining);
+        assert_eq!(vec![false, false], ps.has_secret);
+        assert_eq!(vec![0, 0], ps.traded_counts);
+        let p0 = g.player_state(0);
+        assert_eq!(g.hands[0], p0.hand);
+    }
+
+    #[test]
+    fn test_garbage_command_is_user_error() {
+        let (mut g, _) = Game::start(2, 1).unwrap();
+        let err = g
+            .command(0, "!!! not a command @@@ ###", &names())
+            .unwrap_err();
+        assert!(matches!(err, GameError::InvalidInput { .. }));
+    }
+}

--- a/rust/game/hanamikoji-1/src/render.rs
+++ b/rust/game/hanamikoji-1/src/render.rs
@@ -1,0 +1,279 @@
+use brdgme_color::NamedColor;
+use brdgme_game::Renderer;
+use brdgme_markup::{Align as A, Node as N, Row, table_with_gap};
+
+use crate::card::Geisha;
+use crate::{Pending, Phase, PlayerState, PubState};
+
+const COL_SPACING: usize = 2;
+
+pub fn geisha_node(g: Geisha) -> N {
+    N::Bold(vec![N::Fg(
+        g.color().into(),
+        vec![N::text(g.name().to_string())],
+    )])
+}
+
+pub fn comma_geisha(cards: &[Geisha]) -> Vec<N> {
+    let mut out: Vec<N> = vec![];
+    for (i, g) in cards.iter().enumerate() {
+        if i > 0 {
+            out.push(N::text(", "));
+        }
+        out.push(geisha_node(*g));
+    }
+    out
+}
+
+fn grey(text: &str) -> N {
+    N::Fg(NamedColor::Grey.into(), vec![N::text(text.to_string())])
+}
+
+fn marker_nodes(marker: Option<usize>) -> Vec<N> {
+    match marker {
+        Some(0) => vec![N::Bold(vec![N::text("< ")]), N::Player(0)],
+        Some(1) => vec![N::Player(1), N::Bold(vec![N::text(" >")])],
+        _ => vec![grey("-")],
+    }
+}
+
+fn actions_node(used: [bool; 4]) -> N {
+    let labels = ["S", "T", "G", "C"];
+    let mut nodes: Vec<N> = vec![];
+    for (k, label) in labels.iter().enumerate() {
+        if k > 0 {
+            nodes.push(N::text(" "));
+        }
+        let letter = N::text(label.to_string());
+        nodes.push(if used[k] {
+            grey(label)
+        } else {
+            N::Bold(vec![N::Fg(NamedColor::Green.into(), vec![letter])])
+        });
+    }
+    N::Group(nodes)
+}
+
+fn board_table(pub_state: &PubState) -> Vec<Row> {
+    let mut rows: Vec<Row> = vec![vec![
+        (A::Left, vec![N::Bold(vec![N::text("Geisha")])]),
+        (A::Center, vec![N::Bold(vec![N::text("Charm")])]),
+        (A::Center, vec![N::Player(0)]),
+        (A::Center, vec![N::Bold(vec![N::text("Marker")])]),
+        (A::Center, vec![N::Player(1)]),
+    ]];
+    for g in Geisha::ALL {
+        let i = g.index();
+        let faceup = pub_state.faceup.get(i).copied().unwrap_or([0, 0]);
+        let marker = pub_state.marker.get(i).copied().unwrap_or(None);
+        rows.push(vec![
+            (A::Left, vec![geisha_node(g)]),
+            (A::Center, vec![N::text(g.charm().to_string())]),
+            (
+                A::Center,
+                vec![N::Bold(vec![N::text(faceup[0].to_string())])],
+            ),
+            (A::Center, marker_nodes(marker)),
+            (
+                A::Center,
+                vec![N::Bold(vec![N::text(faceup[1].to_string())])],
+            ),
+        ]);
+    }
+    rows
+}
+
+fn summary_table(pub_state: &PubState) -> Vec<Row> {
+    let mut rows: Vec<Row> = vec![vec![
+        (A::Left, vec![N::Bold(vec![N::text("Player")])]),
+        (A::Center, vec![N::Bold(vec![N::text("Geisha")])]),
+        (A::Center, vec![N::Bold(vec![N::text("Charm")])]),
+        (A::Center, vec![N::Bold(vec![N::text("Hand")])]),
+        (A::Center, vec![N::Bold(vec![N::text("Secret")])]),
+        (A::Center, vec![N::Bold(vec![N::text("Traded")])]),
+        (A::Left, vec![N::Bold(vec![N::text("Actions")])]),
+    ]];
+    for p in 0..pub_state.players {
+        let used = pub_state.used.get(p).copied().unwrap_or([true; 4]);
+        rows.push(vec![
+            (A::Left, vec![N::Player(p)]),
+            (
+                A::Center,
+                vec![N::Bold(vec![N::text(
+                    pub_state
+                        .geisha_counts
+                        .get(p)
+                        .copied()
+                        .unwrap_or(0)
+                        .to_string(),
+                )])],
+            ),
+            (
+                A::Center,
+                vec![N::Bold(vec![N::text(
+                    pub_state.charms.get(p).copied().unwrap_or(0).to_string(),
+                )])],
+            ),
+            (
+                A::Center,
+                vec![N::text(
+                    pub_state
+                        .hand_counts
+                        .get(p)
+                        .copied()
+                        .unwrap_or(0)
+                        .to_string(),
+                )],
+            ),
+            (
+                A::Center,
+                vec![if pub_state.has_secret.get(p).copied().unwrap_or(false) {
+                    N::text("yes")
+                } else {
+                    grey("-")
+                }],
+            ),
+            (
+                A::Center,
+                vec![N::text(
+                    pub_state
+                        .traded_counts
+                        .get(p)
+                        .copied()
+                        .unwrap_or(0)
+                        .to_string(),
+                )],
+            ),
+            (A::Left, vec![actions_node(used)]),
+        ]);
+    }
+    rows
+}
+
+fn pending_nodes(pub_state: &PubState) -> Option<N> {
+    let pending = pub_state.pending.as_ref()?;
+    let line = match pending {
+        Pending::Gift { actor, cards } => {
+            let mut line = vec![
+                N::Bold(vec![N::text("Gift: ")]),
+                N::Player(*actor),
+                N::text(" offered "),
+            ];
+            line.extend(comma_geisha(cards));
+            line.push(N::text(" - "));
+            line.push(N::Player(1 - *actor));
+            line.push(N::Bold(vec![N::text(" chooses one")]));
+            line
+        }
+        Pending::Competition { actor, sets } => {
+            let mut line = vec![
+                N::Bold(vec![N::text("Competition: ")]),
+                N::Player(*actor),
+                N::text(" offered set 1 { "),
+            ];
+            line.extend(comma_geisha(&sets[0]));
+            line.push(N::text(" } and set 2 { "));
+            line.extend(comma_geisha(&sets[1]));
+            line.push(N::text(" } - "));
+            line.push(N::Player(1 - *actor));
+            line.push(N::Bold(vec![N::text(" chooses a set")]));
+            line
+        }
+    };
+    Some(N::Group(line))
+}
+
+fn render(
+    pub_state: &PubState,
+    player: Option<usize>,
+    hand: Option<&[Geisha]>,
+    secret: Option<Option<Geisha>>,
+    traded: Option<&[Geisha]>,
+) -> Vec<N> {
+    let mut out: Vec<N> = vec![];
+
+    if pub_state.finished {
+        if let Some(w) = pub_state.winner {
+            out.push(N::Bold(vec![
+                N::text("Game over - "),
+                N::Player(w),
+                N::text(" wins!"),
+            ]));
+        }
+    } else {
+        match pub_state.phase {
+            Phase::ChooseAction => out.push(N::Bold(vec![
+                N::Player(pub_state.current),
+                N::text("'s turn - choose an action (secret, trade, gift or compete)"),
+            ])),
+            Phase::OpponentChoose => out.push(N::Bold(vec![
+                N::Player(1 - pub_state.current),
+                N::text(" chooses from the pending cards"),
+            ])),
+            Phase::Finished => {}
+        }
+    }
+    out.push(N::text(format!(
+        "Round {}  -  {} cards left in the deck\n",
+        pub_state.round, pub_state.deck_remaining
+    )));
+
+    if let Some(pending) = pending_nodes(pub_state) {
+        out.push(pending);
+        out.push(N::text("\n"));
+    }
+
+    out.push(table_with_gap(&board_table(pub_state), COL_SPACING));
+    out.push(N::text("\n"));
+    out.push(table_with_gap(&summary_table(pub_state), COL_SPACING));
+
+    if player.is_some() {
+        out.push(N::text("\n"));
+        if let Some(h) = hand {
+            out.push(N::Bold(vec![N::text("Your hand: ")]));
+            if h.is_empty() {
+                out.push(grey("empty"));
+            } else {
+                out.push(N::Group(comma_geisha(h)));
+            }
+            out.push(N::text("\n"));
+        }
+        if let Some(sec) = secret {
+            out.push(N::Bold(vec![N::text("Your secret: ")]));
+            match sec {
+                Some(g) => out.push(geisha_node(g)),
+                None => out.push(grey("none")),
+            }
+            out.push(N::text("\n"));
+        }
+        if let Some(tr) = traded {
+            out.push(N::Bold(vec![N::text("Your trade-off discard: ")]));
+            if tr.is_empty() {
+                out.push(grey("none"));
+            } else {
+                out.push(N::Group(comma_geisha(tr)));
+            }
+            out.push(N::text("\n"));
+        }
+    }
+
+    out
+}
+
+impl Renderer for PubState {
+    fn render(&self) -> Vec<N> {
+        render(self, None, None, None, None)
+    }
+}
+
+impl Renderer for PlayerState {
+    fn render(&self) -> Vec<N> {
+        render(
+            &self.public,
+            Some(self.player),
+            Some(&self.hand),
+            Some(self.secret),
+            Some(&self.traded),
+        )
+    }
+}

--- a/rust/game/hanamikoji-1/tests/contract.rs
+++ b/rust/game/hanamikoji-1/tests/contract.rs
@@ -1,0 +1,7 @@
+use brdgme_cmd::test_support::assert_gamer_contract;
+use hanamikoji_1::Game;
+
+#[test]
+fn game_contract() {
+    assert_gamer_contract::<Game>();
+}


### PR DESCRIPTION
## What this is

A new game port: `hanamikoji-1`, a two-player geisha card game, added under
`rust/game/hanamikoji-1/`.

This came out of an autonomous stretch session.

## Contents

- New crate `rust/game/hanamikoji-1/` (engine, command layer, rendering,
  CLI/fuzz/HTTP bin stubs), wired into the workspace `Cargo.toml`/`Cargo.lock`.
- Rules and design docs: `RULES.md`, `DATA_DOCS.md`, `BASIC_STRATEGY.md`,
  `ADVANCED_STRATEGY.md`, `PORTING_NOTES.md`.
- Test coverage including a full playthrough, command round-trips, epilogue
  handling, and multibyte input.

Diff: 16 files changed, 2237 insertions(+).

## Status

- 28 tests.
- Full `rust-test.sh` gate green.
- Deliberately undeployed: no Dockerfile, no k8s manifests, no CRD. Deployment
  wiring is the follow-up, per the lords-of-vegas-1 precedent.
- Rules docs are original wording.

## Review attention

Please review the game engine and command handling for correctness, and
confirm the "undeployed for now" scope matches the lords-of-vegas-1 precedent
before any deployment follow-up is scheduled.
